### PR TITLE
fix urls.py priority

### DIFF
--- a/knowledge/urls.py
+++ b/knowledge/urls.py
@@ -5,11 +5,11 @@ urlpatterns = patterns('knowledge.views',
 
     url(r'^questions/$', 'knowledge_list', name='knowledge_list'),
 
-    url(r'^questions/(?P<category_slug>[a-z0-9-_]+)/$', 'knowledge_list',
-        name='knowledge_list_category'),
-
     url(r'^questions/(?P<question_id>\d+)/$',
         'knowledge_thread', name='knowledge_thread_no_slug'),
+
+    url(r'^questions/(?P<category_slug>[a-z0-9-_]+)/$', 'knowledge_list',
+        name='knowledge_list_category'),
 
     url(r'^questions/(?P<question_id>\d+)/(?P<slug>[a-z0-9-_]+)/$',
         'knowledge_thread', name='knowledge_thread'),


### PR DESCRIPTION
Previous urls.py priority will cause question page not accessible,
but category page instead, when SLUG_URLS is set to False.

I use Chinese, so slug is almost useless, so I turn it off.
