### PR TITLE
Default value for BASE_TEMPLATE in inner.html

### DIFF
--- a/knowledge/templates/django_knowledge/inner.html
+++ b/knowledge/templates/django_knowledge/inner.html
@@ -1,4 +1,4 @@
-{% extends BASE_TEMPLATE %}
+{% extends BASE_TEMPLATE|default:'django_knowledge/base.html' %}
 
 {% load i18n %}
 {% load url from future %}


### PR DESCRIPTION
Hello again !

Here's a little fix to address the issue you mentioned about BASE_TEMPLATE variable passing.

If the template argument is forgotten, it defaults to bundled base template.
